### PR TITLE
Missing comma separating packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     license='MIT',
     install_requires=[
         'requests',
-        'python-dateutil'
+        'python-dateutil',
         'pytz',
     ],   
 )


### PR DESCRIPTION
Added a missing comma in the install requires of `setup.py` which without results in this error when attempting to install from pip, `No matching distribution found for python-dateutilpytz`.